### PR TITLE
fix: return error

### DIFF
--- a/pkg/lambda/handler.go
+++ b/pkg/lambda/handler.go
@@ -91,7 +91,7 @@ func (handler *Handler) extractRecords(ev *Event) ([]*Record, []*firehose.Record
 	return records, blockRecords, countRecords
 }
 
-func (handler *Handler) Do(ctx context.Context, ev *Event) *Event {
+func (handler *Handler) Do(ctx context.Context, ev *Event) (*Event, error) {
 	lc, _ := lambdacontext.FromContext(ctx)
 	requestID := lc.AwsRequestID
 
@@ -130,5 +130,5 @@ func (handler *Handler) Do(ctx context.Context, ev *Event) *Event {
 
 	return &Event{
 		Records: records,
-	}
+	}, nil
 }


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html

> The handler may return between 0 and 2 arguments.
> If there is a single return value, it must implement error.
> If there are two return values, the second value must implement error.